### PR TITLE
Added tcl script to write arty_a7 spi memory

### DIFF
--- a/build/write_spi_arty_a7.tcl
+++ b/build/write_spi_arty_a7.tcl
@@ -1,0 +1,49 @@
+#==============================================================================
+# Instructions to flash a device.
+#
+# Command to invoke:
+# vivado -mode batch -source <script> -log <log_file> -tclargs <configuration file>
+# Example:
+# vivado -mode batch -source flash_arty_a7.tcl -log flash_vivado.log \
+#        -tclargs current_netlist/msftDvIp_cheri_arty7_fpga_cheri_arty7_RUN_1715265194.mcs
+#==============================================================================
+
+set CfgFile [lindex $argv 0 ]
+
+#=============================================
+# Connecting to the server
+#=============================================
+# open_hw_manager
+open_hw_manager
+connect_hw_server -url localhost:3121
+current_hw_target [get_hw_targets */xilinx_tcf/Digilent/*]
+open_hw_target
+
+#=============================================
+# Programming the device
+#=============================================
+current_hw_device [lindex [get_hw_devices] 0]
+refresh_hw_device -update_hw_probes false [lindex [get_hw_devices] 0]
+
+create_hw_cfgmem -hw_device [lindex [get_hw_devices] 0] -mem_dev [lindex [get_cfgmem_parts {s25fl128sxxxxxx0-spi-x1_x2_x4}] 0]
+set_property PROGRAM.ADDRESS_RANGE  {use_file} [ get_property PROGRAM.HW_CFGMEM [lindex [get_hw_devices] 0]]
+set_property PROGRAM.FILES [list "${CfgFile}" ] [ get_property PROGRAM.HW_CFGMEM [lindex [get_hw_devices] 0]]
+set_property PROGRAM.PRM_FILE {} [ get_property PROGRAM.HW_CFGMEM [lindex [get_hw_devices] 0]]
+set_property PROGRAM.UNUSED_PIN_TERMINATION {pull-none} [ get_property PROGRAM.HW_CFGMEM [lindex [get_hw_devices] 0]]
+set_property PROGRAM.BLANK_CHECK  0 [ get_property PROGRAM.HW_CFGMEM [lindex [get_hw_devices] 0]]
+set_property PROGRAM.ERASE  1 [ get_property PROGRAM.HW_CFGMEM [lindex [get_hw_devices] 0]]
+set_property PROGRAM.CFG_PROGRAM  1 [ get_property PROGRAM.HW_CFGMEM [lindex [get_hw_devices] 0]]
+set_property PROGRAM.VERIFY  1 [ get_property PROGRAM.HW_CFGMEM [lindex [get_hw_devices] 0]]
+set_property PROGRAM.CHECKSUM  0 [ get_property PROGRAM.HW_CFGMEM [lindex [get_hw_devices] 0]]
+
+startgroup 
+create_hw_bitstream -hw_device [lindex [get_hw_devices] 0] [get_property PROGRAM.HW_CFGMEM_BITFILE [ lindex [get_hw_devices] 0]]
+program_hw_devices [lindex [get_hw_devices] 0]
+refresh_hw_device [lindex [get_hw_devices] 0]
+program_hw_cfgmem -hw_cfgmem [ get_property PROGRAM.HW_CFGMEM [lindex [get_hw_devices] 0]]
+endgroup
+
+#=============================================
+# Close
+#=============================================
+close_hw_manager


### PR DESCRIPTION
Write to the spi memory the arty_a7 board allowing the board to start the application at boot.

**Description**
Added a tcl script that can write to the arty_a7 spi memory chip.
The script seems to work for me and might be able to be used for other diligent boards.

The commands in the script came from seeing what commands are executed when writing the spi memory from the gui and also the below documentation:
https://docs.amd.com/r/2023.1-English/ug908-vivado-programming-debugging/Opening-a-Hardware-Target-Using-Tcl-Commands

A possible improvements is selecting the latest _.msc_ file from the current netlist automatically