### PR TITLE
`mmreg` fix pollable interrupt status

### DIFF
--- a/src/msft_cheri_subsystem/msftDvIp_mmreg.sv
+++ b/src/msft_cheri_subsystem/msftDvIp_mmreg.sv
@@ -73,18 +73,17 @@ module msftDvIp_mmreg (
         case(reg_addr_i[7:2])
           6'h0: tbre_start_addr <= reg_wdata_i;
           6'h1: tbre_end_addr   <= reg_wdata_i;
+          6'h2: tbre_go         <= 1'b1;
           // Used to clear the interrupt status register when interrupts
           // disabled.
           6'h4: tbre_intr_stat  <= 1'b0;
           6'h5: tbre_intr_en    <= reg_wdata_i[0];
-          default:;
+          default:
+                tbre_go <= 1'b0;
         endcase
-      end
-
-      if (wr_op && (reg_addr_i[7:2] == 6'h2))
-        tbre_go <= 1'b1;
-      else
+      end else begin
         tbre_go <= 1'b0;
+      end
 
       tbre_stat_q <= tbre_stat;
       

--- a/src/msft_cheri_subsystem/msftDvIp_mmreg.sv
+++ b/src/msft_cheri_subsystem/msftDvIp_mmreg.sv
@@ -73,6 +73,9 @@ module msftDvIp_mmreg (
         case(reg_addr_i[7:2])
           6'h0: tbre_start_addr <= reg_wdata_i;
           6'h1: tbre_end_addr   <= reg_wdata_i;
+          // Used to clear the interrupt status register when interrupts
+          // disabled.
+          6'h4: tbre_intr_stat  <= 1'b0;
           6'h5: tbre_intr_en    <= reg_wdata_i[0];
           default:;
         endcase
@@ -108,6 +111,9 @@ module msftDvIp_mmreg (
           6'h1:    reg_rdata_o <= tbre_end_addr;
           6'h2:    reg_rdata_o <= {32'h55000000};
           6'h3:    reg_rdata_o <= {tbre_epoch, tbre_stat};
+          // This is used to poll the interrupt status when interrupts are
+          // disabled.
+          6'h4:    reg_rdata_o <= {31'h0, (~tbre_intr_en ? tbre_intr_stat : 1'b0)};
           6'h5:    reg_rdata_o <= {31'h0, tbre_intr_en};
           6'h10:   reg_rdata_o <= {23'h0, dbg_fifo_empty, dbg_fifo_rd_data};
           6'h11:   reg_rdata_o <= {22'h0, dbg_fifo_full, dbg_fifo_empty, 3'h0, dbg_fifo_depth};

--- a/src/msft_cheri_subsystem/msftDvIp_mmreg.sv
+++ b/src/msft_cheri_subsystem/msftDvIp_mmreg.sv
@@ -106,9 +106,8 @@ module msftDvIp_mmreg (
         casez(reg_addr_i[7:2]) 
           6'h0:    reg_rdata_o <= tbre_start_addr;
           6'h1:    reg_rdata_o <= tbre_end_addr;
-          6'h2:    reg_rdata_o <= {16'h5500, 15'h0, tbre_go};
+          6'h2:    reg_rdata_o <= {32'h55000000};
           6'h3:    reg_rdata_o <= {tbre_epoch, tbre_stat};
-          6'h4:    reg_rdata_o <= {31'h0, tbre_intr_stat};
           6'h5:    reg_rdata_o <= {31'h0, tbre_intr_en};
           6'h10:   reg_rdata_o <= {23'h0, dbg_fifo_empty, dbg_fifo_rd_data};
           6'h11:   reg_rdata_o <= {22'h0, dbg_fifo_full, dbg_fifo_empty, 3'h0, dbg_fifo_depth};


### PR DESCRIPTION
This essentially removes the debug signals and wires from the `mmreg` module. It doesn't make much sense to expose these to software and with hardware simulation you can derive these signals from existing ones.

It also removes `tbre_go` and `tbre_intr_stat` from the read register interface. These signals are only set for one cycle and it doesn't make sense to expose that over a bus interface.