### PR TITLE
Fixing safe/PLIC design 

### DIFF
--- a/src/msft_cheri_subsystem/msftDvIp_plic.sv
+++ b/src/msft_cheri_subsystem/msftDvIp_plic.sv
@@ -80,8 +80,8 @@ module msftDvIp_plic #(
   for (genvar i = 0; i < nIntrSrc; i++) begin : g_pending
     assign irq_sig[i] = intr_src_type_reg[i] ? irqs_i[i] & ~irqs_q[i] : irqs_i[i];   // edge or level triggering
 
-    assign claim_dec[i]      = claim_event && (intr_id == i+1);
-    assign completion_dec[i] = completion_event  && (reg_wdata_i[IntrIdW-1:0] == i+1);
+    assign claim_dec[i]      = claim_event && (intr_id == i);
+    assign completion_dec[i] = completion_event  && (reg_wdata_i[IntrIdW-1:0] == i);
 
     always_ff @(posedge clk_i or negedge rstn_i) begin
       if (!rstn_i) begin
@@ -113,7 +113,7 @@ module msftDvIp_plic #(
 
   for (genvar i = 0; i < 32; i++) begin : gen_tree_inputs
     if (i < nIntrSrc) begin
-      assign id_tree[0][i]  = i+1;
+      assign id_tree[0][i]  = i;
       assign pri_tree[0][i] = (intr_pending[i] & intr_enable_reg[i]) ? intr_pri_reg[i] : 0;
     end else begin
       assign id_tree[0][i]  = 0;

--- a/src/msft_cheri_subsystem/msftDvIp_plic.sv
+++ b/src/msft_cheri_subsystem/msftDvIp_plic.sv
@@ -20,7 +20,7 @@ module msftDvIp_plic #(
 
   localparam IntrIdW      = $clog2(nIntrSrc)+1;
 
-  localparam PriRegAddrBase = 26'h4 >> 2; 
+  localparam PriRegAddrBase = 26'h0 >> 2; 
   localparam EnableRegAddr  = 26'h2000 >> 2;
   localparam ThresRegAddr   = 26'h200000 >> 2;
   localparam ClaimRegAddr   = 26'h200004 >> 2;

--- a/src/msft_cheri_subsystem/msftDvIp_tcdev_wrapper.sv
+++ b/src/msft_cheri_subsystem/msftDvIp_tcdev_wrapper.sv
@@ -44,7 +44,8 @@ module msftDvIp_tcdev_wrapper (
   logic [31:0] rdata_plic, rdata_mmreg, rdata_clint, rdata_eth_mac;     
   logic        eth_tx_irq, eth_rx_irq;
 
-  assign irq_to_plic = {28'h0, eth_rx_irq, eth_tx_irq, irq_periph_i, irq_tbre}; 
+  // PLIC says we can't use irq #0 since ID==1 means no interrupt..
+  assign irq_to_plic = {27'h0, eth_rx_irq, eth_tx_irq, irq_periph_i, irq_tbre, 1'b0}; 
 
   assign reg_ready_o = 1'b1;
 


### PR DESCRIPTION
The current safe/PLIC doesn't handle intr_ID correctly per RV-PLIC spec. IntrID==0 should be reserved for no interrupt and thus all actual interrupts should starts at IntrID==1. The corresponding register address base needs update as well.