### PR TITLE
Don't use blocking assignments for RAM writes

### DIFF
--- a/src/msft_cheri_arty7/msftDvIp_axi_mem_bit_write.sv
+++ b/src/msft_cheri_arty7/msftDvIp_axi_mem_bit_write.sv
@@ -496,8 +496,8 @@ begin
     if(we_ram) begin
       for(i=0;i<RAM_WIDTH;i=i+1) begin
         if(wstrb_ram[i]) begin
-          ram[addr_ram][i] = din_ram[i];
-        end 
+          ram[addr_ram][i] <= din_ram[i];
+        end
       end
     end else begin
       ram_rd_data <= ram[addr_ram];

--- a/src/msft_cheri_subsystem/msftDvIp_axi_mem_bit_write.sv
+++ b/src/msft_cheri_subsystem/msftDvIp_axi_mem_bit_write.sv
@@ -496,8 +496,8 @@ begin
     if(we_ram) begin
       for(i=0;i<RAM_WIDTH;i=i+1) begin
         if(wstrb_ram[i]) begin
-          ram[addr_ram][i] = din_ram[i];
-        end 
+          ram[addr_ram][i] <= din_ram[i];
+        end
       end
     end else begin
       ram_rd_data <= ram[addr_ram];

--- a/src/msft_cheri_subsystem/msftDvIp_fpga_block_ram_2port_model.sv
+++ b/src/msft_cheri_subsystem/msftDvIp_fpga_block_ram_2port_model.sv
@@ -81,8 +81,8 @@ begin
       integer i;
       for(i=0;i<RAM_WIDTH;i=i+1) begin
         if(wstrb_ram[i]) begin
-          ram[addr_ram][i] = din_ram[i];
-        end 
+          ram[addr_ram][i] <= din_ram[i];
+        end
       end
     end else begin
       ram_rd_data <= ram[addr_ram];

--- a/src/msft_cheri_subsystem/msftDvIp_fpga_block_ram_byte_wr_model.sv
+++ b/src/msft_cheri_subsystem/msftDvIp_fpga_block_ram_byte_wr_model.sv
@@ -91,8 +91,8 @@ begin
       integer i;
       for(i=0;i<RAM_WIDTH;i=i+1) begin
         if(wstrb_ram[i]) begin
-          ram[addr_ram][i] = din_ram[i];
-        end 
+          ram[addr_ram][i] <= din_ram[i];
+        end
       end
     end else begin
       ram_rd_data <= ram[addr_ram];


### PR DESCRIPTION
This prevents inference by Slang (in the OSS Yosys-Slang synthesis flow):

    .../msftDvIp_fpga_block_ram_byte_wr_model.sv:23:24: error: cannot infer memory from a variable despite 'ram_style' attribute
    reg [RAM_WIDTH-1:0]    ram [RAM_DEPTH-1:0];
                        ^
    .../msftDvIp_fpga_block_ram_byte_wr_model.sv:95:11: note: inference prevented by variable usage here
            ram[addr_ram][i] = din_ram[i];
            ^

(The above message only appears with `ram_style="block"` attribute. Without the attribute the only sign that anything went wrong is very long synthesis times.)